### PR TITLE
Clarify thread comment in EmailValidate example step

### DIFF
--- a/ExampleSteps/src/main/java/com/experian/aperture/datastudio/sdk/step/examples/EmailValidate.java
+++ b/ExampleSteps/src/main/java/com/experian/aperture/datastudio/sdk/step/examples/EmailValidate.java
@@ -122,7 +122,7 @@ public class EmailValidate extends StepConfiguration {
             final String selectedColumnName = getArgument(0);
             final StepColumn selectedColumn = getColumnManager().getColumnByName(selectedColumnName);
 
-            // queue up to 1000 threads, for processing BLOCK_SIZE times simultaneously
+            // queue up to THREAD_SIZE threads, for processing BLOCK_SIZE times simultaneously
             final List<Future> futures = new ArrayList<>();
             for (long rowId = 0L; rowId < rowCount; rowId++) {
                 try {


### PR DESCRIPTION
The thread count is a variable but unlikely to be ever set to 1000!
Comments in this step would be very useful, but if we only have a few they need to be clear and correct!